### PR TITLE
move cache to yarn and cypress default

### DIFF
--- a/vars/node1016BuilderPersistentVolumes.groovy
+++ b/vars/node1016BuilderPersistentVolumes.groovy
@@ -1,9 +1,9 @@
 def call(Map config) {
   return [
     [
-      path: '/home/jenkins/.npm',
+      path: '/home/jenkins/.cache',
       claimName: "${config.project}-home-jenkins-npm",
-      sizeGiB: 1
+      sizeGiB: 1.5
     ]
   ]
 }


### PR DESCRIPTION
Yarn and cypress install into ~/.cache by default, so it's cleaner to move the mount than configure both