### PR TITLE
Support jest-junit >= v8.0.0

### DIFF
--- a/vars/buildNode1016Component.groovy
+++ b/vars/buildNode1016Component.groovy
@@ -10,7 +10,7 @@ def call(Map config) {
   final yarn = { cmd ->
     ansiColor('xterm') {
       dir(config.baseDir) {
-        sh "NODE_OPTIONS=--max-old-space-size=4096 JEST_JUNIT_OUTPUT=${testOutput} yarn ${cmd}"
+        sh "NODE_OPTIONS=--max-old-space-size=4096 JEST_JUNIT_OUTPUT=${testOutput} JEST_JUNIT_OUTPUT_DIR=. JEST_JUNIT_OUTPUT_NAME=${testOutput} yarn ${cmd}"
       }
     }
   }


### PR DESCRIPTION
Version v8.0.0 of jest-junit removed the `JEST_JUNIT_OUTPUT` environment variable in favour of `JEST_JUNIT_OUTPUT_DIR` and `JEST_JUNIT_OUTPUT_NAME`.

I will leave the old environment variable for backwards compatibility as it will just be ignored in newer versions.

https://github.com/jest-community/jest-junit/pull/101