### PR TITLE
Fix environment variable

### DIFF
--- a/vars/buildNode1016Component.groovy
+++ b/vars/buildNode1016Component.groovy
@@ -10,7 +10,7 @@ def call(Map config) {
   final yarn = { cmd ->
     ansiColor('xterm') {
       dir(config.baseDir) {
-        sh "NODE_OPTIONS=--max-old-space-size=4096 JEST_JUNIT_OUTPUT=${testOutput} yarn ${cmd}"
+        sh "NODE_OPTIONS=--max-old-space-size=4096 JEST_JUNIT_OUTPUT_NAME=${testOutput} yarn ${cmd}"
       }
     }
   }


### PR DESCRIPTION
We were using the wrong environment variable to specify the JUnit filename so it was defaulting to junit.xml and Jenkins couldn't find it.
See: https://github.com/jest-community/jest-junit